### PR TITLE
Adjust general information in money destination

### DIFF
--- a/src/config/moneyDestination/moneyDestinationTab/generics/menuOptions/index.tsx
+++ b/src/config/moneyDestination/moneyDestinationTab/generics/menuOptions/index.tsx
@@ -2,7 +2,7 @@ import { MdAdd } from "react-icons/md";
 
 const menuOptionsMoneyDestination = [
   {
-    description: "Agregar nómina",
+    description: "Agregar destino",
     icon: <MdAdd />,
     path: "/money-destination/add-destination",
     disabled: false,

--- a/src/config/moneyDestination/moneyDestinationTab/tabLabels/index.ts
+++ b/src/config/moneyDestination/moneyDestinationTab/tabLabels/index.ts
@@ -3,6 +3,10 @@ const tablabels = {
   searchPlaceholder: "Palabra clave...",
   addButton: " Agregar destino",
   description: " Consulta de destinos de dinero disponibles",
+  emptyDataMessageDesk:
+    "Aún no hay destinos de dinero registrados, presiona “+ Agregar destino” para empezar.",
+  emptyDataMessageMobile:
+    "Aún no hay destinos de dinero registrados, presiona los 3 puntos y luego “+ Agregar destino para empezar.",
 };
 
 export { tablabels };

--- a/src/config/moneyDestination/moneyDestinationTab/tabLabels/index.ts
+++ b/src/config/moneyDestination/moneyDestinationTab/tabLabels/index.ts
@@ -1,4 +1,4 @@
-const tablabels = {
+const tabLabels = {
   searchLabel: "Buscar",
   searchPlaceholder: "Palabra clave...",
   addButton: " Agregar destino",
@@ -9,4 +9,4 @@ const tablabels = {
     "Aún no hay destinos de dinero registrados, presiona los 3 puntos y luego “+ Agregar destino para empezar.",
 };
 
-export { tablabels };
+export { tabLabels };

--- a/src/design/data/table/interface.tsx
+++ b/src/design/data/table/interface.tsx
@@ -86,7 +86,7 @@ const TableUI = (props: ITableUI) => {
                     type="label"
                     size={mediaActionOpen ? "medium" : "large"}
                     appearance={EComponentAppearance.DARK}
-                    ellipsis
+                    textAlign="center"
                   >
                     {emptyDataMessage
                       ? `${emptyDataMessage}`

--- a/src/enum/moneyDestination/index.ts
+++ b/src/enum/moneyDestination/index.ts
@@ -1,0 +1,6 @@
+enum EMoneyDestination {
+  MONEY_DESTINATION = "nameDestination",
+  ICON_DEFAULT = "MdOutlineFax",
+}
+
+export { EMoneyDestination };

--- a/src/hooks/moneyDestination/useGeneralInformationForm/index.tsx
+++ b/src/hooks/moneyDestination/useGeneralInformationForm/index.tsx
@@ -14,12 +14,12 @@ import { IGeneralInformationEntry } from "@ptypes/moneyDestination/tabs/moneyDes
 import { IServerDomain } from "@ptypes/IServerDomain";
 import { IEnumerators } from "@ptypes/IEnumerators";
 import { normalizeNameDestination } from "@utils/destination/normalizeNameDestination";
-import { normalizeCodeDestination } from "@utils/destination/normalizeCodeDestination";
 import { normalizeDestination } from "@utils/destination/normalizeDestination";
 import { normalizeEditDestination } from "@utils/destination/normalizeEditDestination";
 import { normalizeIconDestination } from "@utils/destination/normalizeIconDestination";
 import { normalizeIconTextDestination } from "@utils/destination/normalizeIconTextDestination";
 import { generalInfoLabels } from "@config/moneyDestination/moneyDestinationTab/form/generalInfoLabels";
+import { EMoneyDestination } from "@enum/moneyDestination";
 import { tokens } from "@design/tokens";
 
 const useGeneralInformationForm = (
@@ -68,7 +68,7 @@ const useGeneralInformationForm = (
     return {
       id: item.code,
       label: name,
-      value: name,
+      value: item.code,
     };
   });
 
@@ -90,13 +90,13 @@ const useGeneralInformationForm = (
   const handleChange = (name: string, value: string) => {
     setAutosuggestValue(value);
     formik.setFieldValue(name, value);
+    const equalValueName = value === formik.values.nameDestination;
 
-    if (name === "nameDestination") {
-      const normalizeData = normalizeCodeDestination(value)?.code ?? "";
+    if (name === EMoneyDestination.MONEY_DESTINATION) {
       const description =
-        normalizeDestination(enumData, normalizeData)?.description ?? "";
+        normalizeDestination(enumData, value)?.description ?? "";
 
-      if (value === "") {
+      if (equalValueName || value === "") {
         formik.setFieldValue("description", "");
       } else {
         const currentDescription = formik.values.description ?? "";
@@ -111,9 +111,9 @@ const useGeneralInformationForm = (
     }
   };
 
-  const nameEnum =
-    normalizeCodeDestination(formik.values.nameDestination ?? "")?.code ?? "";
-  const addData = normalizeDestination(enumData, nameEnum);
+  const addData = enumData.find(
+    (item) => item.value === formik.values.nameDestination,
+  )?.type;
 
   const valuesEqual =
     JSON.stringify(initialValues) === JSON.stringify(formik.values);
@@ -155,30 +155,28 @@ const useGeneralInformationForm = (
       let iconData = getNormalizedIcon(initialValues.icon);
 
       if (editDataOption && formik.values.nameDestination) {
-        const editData = normalizeEditDestination(
-          enumData,
-          formik.values.icon ?? "",
-        );
+        const editData = normalizeEditDestination(enumData, formik.values.icon);
 
         iconData =
           editData && isNameDestinationEqual ? (
             getNormalizedIcon(editData?.value)
           ) : addData ? (
-            getNormalizedIcon(addData?.value)
+            getNormalizedIcon(addData)
           ) : (
             <MdOutlineFax size={24} />
           );
 
         iconData ??= getNormalizedIcon(initialValues.icon);
       } else {
-        iconData = getNormalizedIcon(addData?.value);
+        iconData = getNormalizedIcon(addData);
       }
 
       if (editDataOption && valuesEqual) {
         formik.setFieldValue("icon", initialValues.icon);
       } else {
         const normalizedIconValue =
-          normalizeIconTextDestination(iconData)?.value ?? "MdOutlineFax";
+          normalizeIconTextDestination(iconData)?.value ??
+          EMoneyDestination.ICON_DEFAULT;
         formik.setFieldValue("icon", normalizedIconValue);
       }
 

--- a/src/hooks/moneyDestination/useMoneyDestination/index.ts
+++ b/src/hooks/moneyDestination/useMoneyDestination/index.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { IMoneyDestinationData } from "@ptypes/moneyDestination/tabs/moneyDestinationTab/IMoneyDestinationData";
 import { getMoneyDestinationData } from "@services/moneyDestination/getMoneyDestination";
 import { IUseMoneyDestination } from "@ptypes/hooks/moneyDestination/IUseMoneyDestination";
-import { tablabels } from "@config/moneyDestination/moneyDestinationTab/tabLabels";
+import { tabLabels } from "@config/moneyDestination/moneyDestinationTab/tabLabels";
 
 const useMoneyDestination = (props: IUseMoneyDestination) => {
   const { bussinesUnits } = props;
@@ -53,8 +53,8 @@ const useMoneyDestination = (props: IUseMoneyDestination) => {
   const columnWidths = [widthFirstColumn, 55];
 
   const emptyDataMessage = smallScreen
-    ? tablabels.emptyDataMessageMobile
-    : tablabels.emptyDataMessageDesk;
+    ? tabLabels.emptyDataMessageMobile
+    : tabLabels.emptyDataMessageDesk;
 
   return {
     moneyDestination,

--- a/src/hooks/moneyDestination/useMoneyDestination/index.ts
+++ b/src/hooks/moneyDestination/useMoneyDestination/index.ts
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { IMoneyDestinationData } from "@ptypes/moneyDestination/tabs/moneyDestinationTab/IMoneyDestinationData";
 import { getMoneyDestinationData } from "@services/moneyDestination/getMoneyDestination";
 import { IUseMoneyDestination } from "@ptypes/hooks/moneyDestination/IUseMoneyDestination";
+import { tablabels } from "@config/moneyDestination/moneyDestinationTab/tabLabels";
 
 const useMoneyDestination = (props: IUseMoneyDestination) => {
   const { bussinesUnits } = props;
@@ -51,6 +52,10 @@ const useMoneyDestination = (props: IUseMoneyDestination) => {
 
   const columnWidths = [widthFirstColumn, 55];
 
+  const emptyDataMessage = smallScreen
+    ? tablabels.emptyDataMessageMobile
+    : tablabels.emptyDataMessageDesk;
+
   return {
     moneyDestination,
     hasError,
@@ -58,6 +63,7 @@ const useMoneyDestination = (props: IUseMoneyDestination) => {
     loading,
     smallScreen,
     columnWidths,
+    emptyDataMessage,
     handleSearchMoneyDestination,
     setEntryDeleted,
   };

--- a/src/pages/moneyDestination/tabs/forms/generalInformationDestination/interface.tsx
+++ b/src/pages/moneyDestination/tabs/forms/generalInformationDestination/interface.tsx
@@ -1,4 +1,11 @@
-import { Autosuggest, Button, Stack, Text, Textarea } from "@inubekit/inubekit";
+import {
+  Autosuggest,
+  Button,
+  Stack,
+  Text,
+  Textarea,
+  Textfield,
+} from "@inubekit/inubekit";
 import { MdOutlineFax } from "react-icons/md";
 
 import { tokens } from "@design/tokens";
@@ -44,19 +51,36 @@ const GeneralInformationFormUI = (props: IGeneralInformationFormUI) => {
               <Stack direction="column" width="100%" gap={tokens.spacing.s250}>
                 <Stack direction={directionStack} gap={tokens.spacing.s250}>
                   <Stack width={widthStack}>
-                    <Autosuggest
-                      label={generalInfoLabels.name}
-                      name="nameDestination"
-                      id="nameDestination"
-                      placeholder={generalInfoLabels.placeholderName}
-                      value={autosuggestValue}
-                      onChange={onChange}
-                      options={optionsDestination}
-                      onBlur={formik.handleBlur}
-                      size="compact"
-                      fullwidth
-                      invalid={isInvalid(formik, "nameDestination")}
-                    />
+                    {editDataOption ? (
+                      <Textfield
+                        name="nameDestination"
+                        id="nameDestination"
+                        label={generalInfoLabels.name}
+                        placeholder={generalInfoLabels.placeholderName}
+                        size="compact"
+                        value={autosuggestValue}
+                        onChange={formik.handleChange}
+                        onBlur={formik.handleBlur}
+                        status={getFieldState(formik, "nameDestination")}
+                        message={formik.errors.nameDestination}
+                        fullwidth
+                        required
+                      />
+                    ) : (
+                      <Autosuggest
+                        label={generalInfoLabels.name}
+                        name="nameDestination"
+                        id="nameDestination"
+                        placeholder={generalInfoLabels.placeholderName}
+                        value={autosuggestValue}
+                        onChange={onChange}
+                        options={optionsDestination}
+                        onBlur={formik.handleBlur}
+                        size="compact"
+                        fullwidth
+                        invalid={isInvalid(formik, "nameDestination")}
+                      />
+                    )}
                   </Stack>
                   <Stack
                     direction="column"

--- a/src/pages/moneyDestination/tabs/moneyDestinationTab/addDestination/index.tsx
+++ b/src/pages/moneyDestination/tabs/moneyDestinationTab/addDestination/index.tsx
@@ -21,6 +21,10 @@ function AddDestination() {
     saveData,
     showAttentionModal,
     smallScreen,
+    showGoBackModal,
+    handleCloseModal,
+    handleGoBack,
+    handleOpenModal,
     handleNextStep,
     handlePreviousStep,
     handleSubmitClick,
@@ -80,6 +84,10 @@ function AddDestination() {
       setShowAttentionModal={setShowAttentionModal}
       smallScreen={smallScreen}
       onCloseProcess={handleCloseProcess}
+      onGoBack={handleGoBack}
+      showGoBackModal={showGoBackModal}
+      onCloseModal={handleCloseModal}
+      onOpenModal={handleOpenModal}
     />
   );
 }

--- a/src/pages/moneyDestination/tabs/moneyDestinationTab/addDestination/interface.tsx
+++ b/src/pages/moneyDestination/tabs/moneyDestinationTab/addDestination/interface.tsx
@@ -15,8 +15,8 @@ import { IAddDestinationUI } from "@ptypes/moneyDestination/tabs/moneyDestinatio
 import { DecisionModal } from "@design/modals/decisionModal";
 import { portalId } from "@config/portalId";
 import { goBackModal } from "@config/goBackModal";
-import { GeneralInformationForm } from "../../forms/generalInformationDestination";
-import { VerificationForm } from "../../forms/verificationDestination";
+import { GeneralInformationForm } from "@pages/moneyDestination/tabs/forms/generalInformationDestination";
+import { VerificationForm } from "@pages/moneyDestination/tabs/forms/verificationDestination";
 
 const AddDestinationUI = (props: IAddDestinationUI) => {
   const {

--- a/src/pages/moneyDestination/tabs/moneyDestinationTab/addDestination/interface.tsx
+++ b/src/pages/moneyDestination/tabs/moneyDestinationTab/addDestination/interface.tsx
@@ -12,6 +12,9 @@ import { controlsAssisted } from "@config/controlsAssisted";
 import { lineCreditLabels } from "@config/moneyDestination/addDestination/assisted/lineCreditLabels";
 import { addDestinatrionLabels } from "@config/moneyDestination/moneyDestinationTab/addDestinationLabels";
 import { IAddDestinationUI } from "@ptypes/moneyDestination/tabs/moneyDestinationTab/IAddDestinationUI";
+import { DecisionModal } from "@design/modals/decisionModal";
+import { portalId } from "@config/portalId";
+import { goBackModal } from "@config/goBackModal";
 import { GeneralInformationForm } from "../../forms/generalInformationDestination";
 import { VerificationForm } from "../../forms/verificationDestination";
 
@@ -31,6 +34,10 @@ const AddDestinationUI = (props: IAddDestinationUI) => {
     showPendingReqModal,
     showAttentionModal,
     smallScreen,
+    showGoBackModal,
+    onCloseModal,
+    onOpenModal,
+    onGoBack,
     onFinishForm,
     onNextStep,
     onPreviousStep,
@@ -61,6 +68,7 @@ const AddDestinationUI = (props: IAddDestinationUI) => {
             title={addDestinatrionLabels.title}
             description={addDestinatrionLabels.description}
             sizeTitle="large"
+            onClick={onOpenModal}
           />
         </Stack>
         <Stack gap={tokens.spacing.s300} direction="column">
@@ -134,6 +142,16 @@ const AddDestinationUI = (props: IAddDestinationUI) => {
           </Stack>
         </Stack>
       </Stack>
+      {showGoBackModal && (
+        <DecisionModal
+          portalId={portalId}
+          title={goBackModal.title}
+          description={goBackModal.description}
+          actionText={goBackModal.actionText}
+          onCloseModal={onCloseModal}
+          onClick={onGoBack}
+        />
+      )}
     </Stack>
   );
 };

--- a/src/pages/moneyDestination/tabs/moneyDestinationTab/index.tsx
+++ b/src/pages/moneyDestination/tabs/moneyDestinationTab/index.tsx
@@ -14,6 +14,7 @@ function MoneyDestinationTab() {
     loading,
     smallScreen,
     columnWidths,
+    emptyDataMessage,
     handleSearchMoneyDestination,
     setEntryDeleted,
   } = useMoneyDestination({ bussinesUnits: appData.businessUnit.publicCode });
@@ -27,6 +28,7 @@ function MoneyDestinationTab() {
       setEntryDeleted={setEntryDeleted}
       smallScreen={smallScreen}
       columnWidths={columnWidths}
+      emptyDataMessage={emptyDataMessage}
     />
   );
 }

--- a/src/pages/moneyDestination/tabs/moneyDestinationTab/interface.tsx
+++ b/src/pages/moneyDestination/tabs/moneyDestinationTab/interface.tsx
@@ -5,7 +5,7 @@ import { tokens } from "@design/tokens";
 import { EComponentAppearance } from "@enum/appearances";
 import { Table } from "@design/data/table";
 import { IMoneyDestinationTabUI } from "@ptypes/moneyDestination/tabs/moneyDestinationTab/IMoneyDestinationTabUI";
-import { tablabels } from "@config/moneyDestination/moneyDestinationTab/tabLabels";
+import { tabLabels } from "@config/moneyDestination/moneyDestinationTab/tabLabels";
 import {
   actionsConfig,
   breakPoints,
@@ -49,7 +49,7 @@ function MoneyDestinationTabUI(props: IMoneyDestinationTabUI) {
                 appearance={EComponentAppearance.DARK}
                 ellipsis
               >
-                {tablabels.description}
+                {tabLabels.description}
               </Text>
             </Stack>
           )}
@@ -68,8 +68,8 @@ function MoneyDestinationTabUI(props: IMoneyDestinationTabUI) {
               <Searchfield
                 name="searchMoneyDestination"
                 id="searchMoneyDestination"
-                placeholder={tablabels.searchPlaceholder}
-                label={smallScreen ? "" : tablabels.searchLabel}
+                placeholder={tabLabels.searchPlaceholder}
+                label={smallScreen ? "" : tabLabels.searchLabel}
                 size="compact"
                 value={searchMoneyDestination}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -88,7 +88,7 @@ function MoneyDestinationTabUI(props: IMoneyDestinationTabUI) {
                 path="/money-destination/add-destination"
                 fullwidth={smallScreen}
               >
-                {tablabels.addButton}
+                {tabLabels.addButton}
               </Button>
             )}
           </Stack>
@@ -100,7 +100,7 @@ function MoneyDestinationTabUI(props: IMoneyDestinationTabUI) {
                 size="medium"
                 appearance={EComponentAppearance.DARK}
               >
-                {tablabels.description}
+                {tabLabels.description}
               </Text>
             </Stack>
           )}

--- a/src/pages/moneyDestination/tabs/moneyDestinationTab/interface.tsx
+++ b/src/pages/moneyDestination/tabs/moneyDestinationTab/interface.tsx
@@ -21,6 +21,7 @@ function MoneyDestinationTabUI(props: IMoneyDestinationTabUI) {
     loading,
     smallScreen,
     columnWidths,
+    emptyDataMessage,
     onSearchMoneyDestination,
     setEntryDeleted,
   } = props;
@@ -114,6 +115,7 @@ function MoneyDestinationTabUI(props: IMoneyDestinationTabUI) {
             loading={loading}
             columnWidths={columnWidths}
             pageLength={8}
+            emptyDataMessage={emptyDataMessage}
           />
         </Stack>
       </Stack>

--- a/src/types/moneyDestination/tabs/moneyDestinationTab/IAddDestinationUI/index.ts
+++ b/src/types/moneyDestination/tabs/moneyDestinationTab/IAddDestinationUI/index.ts
@@ -20,6 +20,10 @@ interface IAddDestinationUI {
   showPendingReqModal: boolean;
   showAttentionModal: boolean;
   smallScreen: boolean;
+  showGoBackModal: boolean;
+  onCloseModal: () => void;
+  onOpenModal: () => void;
+  onGoBack: () => void;
   onFinishForm: () => void;
   onNextStep: () => void;
   onPreviousStep: () => void;

--- a/src/types/moneyDestination/tabs/moneyDestinationTab/IMoneyDestinationTabUI/index.ts
+++ b/src/types/moneyDestination/tabs/moneyDestinationTab/IMoneyDestinationTabUI/index.ts
@@ -1,11 +1,11 @@
 import { IEntry } from "@ptypes/design/table/IEntry";
-
 interface IMoneyDestinationTabUI {
   entries: IEntry[];
   loading: boolean;
   searchMoneyDestination: string;
   smallScreen: boolean;
   columnWidths: number[];
+  emptyDataMessage: string;
   onSearchMoneyDestination: (e: React.ChangeEvent<HTMLInputElement>) => void;
   setEntryDeleted: (value: string | number) => void;
 }

--- a/src/utils/destination/normalizeCodeDestination/index.ts
+++ b/src/utils/destination/normalizeCodeDestination/index.ts
@@ -1,6 +1,0 @@
-import { nameDestination } from "@config/destination/nameDestination";
-
-const normalizeCodeDestination = (name: string) =>
-  nameDestination.find((element) => element.name === name);
-
-export { normalizeCodeDestination };

--- a/src/utils/destination/normalizeDestination/index.ts
+++ b/src/utils/destination/normalizeDestination/index.ts
@@ -1,6 +1,6 @@
 import { IEnumerators } from "@ptypes/IEnumerators";
 
 const normalizeDestination = (enumData: IEnumerators[], code: string) =>
-  enumData.find((element) => element.code === code);
+  enumData.find((element) => element.value === code);
 
 export { normalizeDestination };

--- a/src/utils/destination/normalizeEditDestination/index.ts
+++ b/src/utils/destination/normalizeEditDestination/index.ts
@@ -1,6 +1,6 @@
 import { IEnumerators } from "@ptypes/IEnumerators";
 
 const normalizeEditDestination = (enumData: IEnumerators[], value: string) =>
-  enumData.find((element) => element.value === value);
+  enumData.find((element) => element.type === value);
 
 export { normalizeEditDestination };


### PR DESCRIPTION
In this PR the tasks are performed:

-Adjust General Information in Money Destination Modification to Make Name Field Unselectable 
[#397](https://github.com/selsa-inube/team-phoenix/issues/397)
-Update No Records Message and Remove Scroll in Details Tab for Money Destinations 
[#395](https://github.com/selsa-inube/team-phoenix/issues/395)
-Add "Go Back" Modal in Add Money Destination Flow
[#396](https://github.com/selsa-inube/team-phoenix/issues/396)

The destination name enumerator service has also been adjusted.